### PR TITLE
num_pages was deprecated - use total_pages instead

### DIFF
--- a/lib/grape/kaminari.rb
+++ b/lib/grape/kaminari.rb
@@ -11,7 +11,7 @@ module Grape
           def paginate(collection)
             collection.page(params[:page]).per(params[:per_page]).padding(params[:offset]).tap do |data|
               header "X-Total",       data.total_count.to_s
-              header "X-Total-Pages", data.num_pages.to_s
+              header "X-Total-Pages", data.total_pages.to_s
               header "X-Per-Page",    data.limit_value.to_s
               header "X-Page",        data.current_page.to_s
               header "X-Next-Page",   data.next_page.to_s


### PR DESCRIPTION
@toastercup num_pages is deprecated and will be removed in Kaminari 1.0, uses total_pages instead per the instruction of the Deprecation Warning that is spamming Cortex's test suite